### PR TITLE
Add JavaScript JSX to the list of languages supported by the extension

### DIFF
--- a/src/definitions.js
+++ b/src/definitions.js
@@ -94,9 +94,9 @@ Defs.newDefinition = function(language, definition) {
 
 Defs.providers = [NullstackDefinitionProvider];
 Defs.definitions = function() {
-  return ['javascript', 'typescriptreact'].map(lang => {
-    return Defs.newDefinition(lang, Defs.providers[0])
-  });
+  return ['javascriptreact', 'typescriptreact'].map(
+    lang => Defs.newDefinition(lang, Defs.providers[0])
+  );
 }
 
 module.exports = Defs;

--- a/tests/definitions.test.js
+++ b/tests/definitions.test.js
@@ -4,11 +4,14 @@ const { mockDocument } = require('./helpers');
 
 it('definitions() registers list of providers', () => {
   const providers = Defs.definitions();
-  expect(vscode.languages.registerDefinitionProvider)
-    .toBeCalledWith(
-      { language: "javascript" },
-      new Defs.providers[0]()
-    );
+
+  expect(vscode.languages.registerDefinitionProvider).toBeCalledTimes(2)
+
+  const languages = ["javascriptreact", "typescriptreact"]
+  for (const language of languages) {
+    expect(vscode.languages.registerDefinitionProvider)
+      .toBeCalledWith({ language }, new Defs.providers[0]());
+  }
   expect(providers).toStrictEqual([true, true]);
 });
 


### PR DESCRIPTION
Since this only affects inner components, it doesn't make sense to look at the non-jsx languages.
This does NOT add new functionality, it just "tags" the already existing logic to work on Javascript JSX files as well.
It's also important to note this does not fully fix issue #2 , since it won't look for the render method in parent classes. I'm planning a future PR to add that.